### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ECMobile
 
 [ECMobile](http://www.ecmobile.cn) 是基于 [ECShop](http://www.ecshop.com) 的手机商城客户端，包括iOS、Android、PHP三个平台源代码及框架已开放下载！
 
-#####支持开源及后续版本更新，请FORK和STAR，感谢您的支持！
+##### 支持开源及后续版本更新，请FORK和STAR，感谢您的支持！
 
 1. iOS: [https://github.com/GeekZooStudio/ECMobile_iOS](https://github.com/GeekZooStudio/ECMobile_iOS)
 2. Android: [https://github.com/GeekZooStudio/ECMobile_Android](https://github.com/GeekZooStudio/ECMobile_Android)

--- a/doc/ECMobile_iOS.md
+++ b/doc/ECMobile_iOS.md
@@ -1,4 +1,4 @@
-#修改工程
+# 修改工程
 
 1. 打开工程
 2. 找到[AppDelegate load]方法，修改 [ServerConfig sharedInstance].url
@@ -30,7 +30,7 @@ siri.config.appID			= @"<Your iflyKey>";
 [ExpressModel setKuaidi100Key:@"<Your kuaidi100Key>"];
 </pre>
 
-#联系方式
+# 联系方式
 
 官方论坛：http://bbs.ecmobile.cn/    
 

--- a/iOS/services/bee.services.location/bee.services.location.md
+++ b/iOS/services/bee.services.location/bee.services.location.md
@@ -1,10 +1,10 @@
-#Step 1
+# Step 1
 
 1. Locate `bee.services.location` under `/services`
 2. Then drag and drop it into your project.
 3. \#import "bee.services.location.h"
 
-#Step 2
+# Step 2
 
 <pre>
 bee.services.location.whenUpdate = ^
@@ -13,11 +13,11 @@ bee.services.location.whenUpdate = ^
 };
 </pre>
 
-#Step 3
+# Step 3
 
 <pre>
 bee.services.location.ON();
 bee.services.location.OFF();
 </pre>
 
-#Good luck
+# Good luck

--- a/iOS/services/bee.services.push/bee.services.push.md
+++ b/iOS/services/bee.services.push/bee.services.push.md
@@ -1,10 +1,10 @@
-#Step 1
+# Step 1
 
 1. Locate `bee.services.push` under `/services`
 2. Then drag and drop it into your project.
 3. \#import "bee.services.push.h"
 
-#Step 2
+# Step 2
 
 <pre>
 bee.services.push.whenRegistered = ^
@@ -20,7 +20,7 @@ bee.services.push.whenReceived = ^
 };
 </pre>
 
-#Step 3
+# Step 3
 
 <pre>
 bee.services.push.ON();
@@ -32,4 +32,4 @@ bee.services.push.CLEAR();
 bee.services.push.CHECK();
 </pre>
 
-#Good luck
+# Good luck

--- a/iOS/services/bee.services.share.sinaweibo/bee.services.share.sinaweibo.md
+++ b/iOS/services/bee.services.share.sinaweibo/bee.services.share.sinaweibo.md
@@ -1,10 +1,10 @@
-#Step 1
+# Step 1
 
 1. Locate `bee.services.share.sinaweibo` under `/services`
 2. Then drag and drop it into your project.
 3. \#import "bee.services.share.sinaweibo.h"
 
-#Step 2
+# Step 2
 
 <pre>
 bee.services.share.sinaweibo.config.appKey = @"<Your app key>";
@@ -13,15 +13,15 @@ bee.services.share.sinaweibo.config.redirectURI = @"<Your redirect url>";
 bee.services.share.sinaweibo.ON();
 </pre>
 
-#Step 3
+# Step 3
 
-####Authorize
+#### Authorize
 
 <pre>
 bee.services.share.sinaweibo.AUTHORIZE();
 </pre>
 
-####Share
+#### Share
 
 <pre>
 bee.services.share.sinaweibo.post.text = @"<Text>";
@@ -41,4 +41,4 @@ bee.services.share.sinaweibo.whenCancelled = ^
 bee.services.share.sinaweibo.SHARE();
 </pre>
 
-#Good luck
+# Good luck

--- a/iOS/services/bee.services.share.tencentweibo/bee.services.share.tencentweibo.md
+++ b/iOS/services/bee.services.share.tencentweibo/bee.services.share.tencentweibo.md
@@ -1,10 +1,10 @@
-#Step 1
+# Step 1
 
 1. Locate `bee.services.share.tencentweibo` under `/services`
 2. Then drag and drop it into your project.
 3. \#import "bee.services.share.tencentweibo.h"
 
-#Step 2
+# Step 2
 
 <pre>
 bee.services.share.tencentweibo.config.appKey = @"<Your app key>";
@@ -13,15 +13,15 @@ bee.services.share.tencentweibo.config.redirectURI = @"<Your redirect url>";
 bee.services.share.tencentweibo.ON();
 </pre>
 
-#Step 3
+# Step 3
 
-####Authorize
+#### Authorize
 
 <pre>
 bee.services.share.tencentweibo.AUTHORIZE();
 </pre>
 
-####Share
+#### Share
 
 <pre>
 bee.services.share.tencentweibo.post.text = @"<Text>";
@@ -41,4 +41,4 @@ bee.services.share.tencentweibo.whenCancelled = ^
 bee.services.share.tencentweibo.SHARE();
 </pre>
 
-#Good luck
+# Good luck

--- a/iOS/services/bee.services.share.weixin/bee.services.share.weixin.md
+++ b/iOS/services/bee.services.share.weixin/bee.services.share.weixin.md
@@ -1,10 +1,10 @@
-#Step 1
+# Step 1
 
 1. Locate `bee.services.share.tencentweibo` under `/services`
 2. Then drag and drop it into your project.
 3. \#import "bee.services.share.tencentweibo.h"
 
-#Step 2
+# Step 2
 
 Add below into your .plist file
 
@@ -23,7 +23,7 @@ Add below into your .plist file
 		</dict>
 	</array>
 
-#Step 2
+# Step 2
 
 <pre>
 bee.services.share.weixin.config.appId = @"<Your app id>";
@@ -31,7 +31,7 @@ bee.services.share.weixin.config.appKey = @"<Your app key>";
 bee.services.share.weixin.ON();
 </pre>
 
-#Step 4
+# Step 4
 
 <pre>
 if ( bee.services.share.weixin.installed )
@@ -53,4 +53,4 @@ else
 }
 </pre>
 
-#Good luck
+# Good luck

--- a/iOS/services/bee.services.siri/bee.services.siri.md
+++ b/iOS/services/bee.services.siri/bee.services.siri.md
@@ -1,7 +1,7 @@
-#Step 1
+# Step 1
 
 1. Locate `bee.services.siri` under `/services`
 2. Then drag and drop it into your project.
 3. \#import "bee.services.siri.h"
 
-#Good luck
+# Good luck

--- a/iOS/services/bee.services.wizard/bee.services.wizard.md
+++ b/iOS/services/bee.services.wizard/bee.services.wizard.md
@@ -1,10 +1,10 @@
-#Step 1
+# Step 1
 
 1. Locate `bee.services.wizard` under `/services`
 2. Then drag and drop it into your project.
 3. \#import "bee.services.wizard.h"
 
-#Step 2
+# Step 2
 
 <pre>
 bee.services.wizard.config.showPageControl = YES;
@@ -26,11 +26,11 @@ bee.services.wizard.whenSkipped = ^{
 };
 </pre>
 
-#Step 3
+# Step 3
 
 <pre>
 bee.services.wizard.ON();
 bee.services.wizard.OFF();
 </pre>
 
-#Good luck
+# Good luck


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
